### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/ServerlessPluginBespoken.ts
+++ b/src/ServerlessPluginBespoken.ts
@@ -242,19 +242,22 @@ export class ServerlessPluginBespoken {
             "Specify the function in your config that you want to use" +
             '(e.g. "--function myFunction" or "-f myFunction")',
           required: false,
-          shortcut: "f"
+          shortcut: "f",
+          type: "string"
         },
         secure: {
           usage:
             "Make bespoken server to require that 'secure' token be specified -- used to reduce likelihood of arbitrary hosts contacting your service via the proxy server",
           required: false,
-          shortcut: "s"
+          shortcut: "s",
+          type: "string"
         },
         "with-passthru-routing": {
           usage:
             "Configure local proxy server to route requests to lambda functions based on url.  'function' option is ignored if this option is specified.  " +
             "This option would normally be enabled after deploying passthru's with `deploy-passthru`",
-          required: false
+          required: false,
+          type: "boolean"
         }
       }
     }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessPluginBespoken for "function", "secure", "with-passthru-routing"
```